### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/nanoframework_build.yml
+++ b/.github/workflows/nanoframework_build.yml
@@ -91,7 +91,7 @@ jobs:
         if: ${{ matrix.configuration == 'Release' }}
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4.1.0
         if: ${{ matrix.configuration == 'Release' }}
         with:
           name: TekuSP-Drivers


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.1.0](https://github.com/actions/upload-artifact/releases/tag/v4.1.0)** on 2024-01-12T17:26:10Z
