### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/actions_update.yml
+++ b/.github/workflows/actions_update.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.1.4
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v4.1.4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/nanoframework_build.yml
+++ b/.github/workflows/nanoframework_build.yml
@@ -20,7 +20,7 @@ jobs:
       solution: 'Meteostanice.sln'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.4
         with:
           fetch-depth: 0
           
@@ -91,7 +91,7 @@ jobs:
         if: ${{ matrix.configuration == 'Release' }}
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4.3.3
         if: ${{ matrix.configuration == 'Release' }}
         with:
           name: TekuSP-Drivers

--- a/.github/workflows/nanoframework_changelog.yml
+++ b/.github/workflows/nanoframework_changelog.yml
@@ -8,7 +8,7 @@ jobs:
     name: Update Changelog
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.1.4
         with:
           fetch-depth: 0
       - name: Update Changelog
@@ -18,7 +18,7 @@ jobs:
           ./git-chglog -o CHANGELOG.md
           rm git-chglog
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6.0.2
+        uses: peter-evans/create-pull-request@v6.0.5
         with:
           commit-message: update changelog
           title: Update Changelog

--- a/.github/workflows/nanoframework_dependabot.yml
+++ b/.github/workflows/nanoframework_dependabot.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.4
         with:
           path: main
       - name: Install NuGet client


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v6.0.5](https://github.com/peter-evans/create-pull-request/releases/tag/v6.0.5)** on 2024-04-25T08:12:55Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.3.3](https://github.com/actions/upload-artifact/releases/tag/v4.3.3)** on 2024-04-22T16:21:25Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.4](https://github.com/actions/checkout/releases/tag/v4.1.4)** on 2024-04-24T13:33:24Z
