### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/nanoframework_changelog.yml
+++ b/.github/workflows/nanoframework_changelog.yml
@@ -18,7 +18,7 @@ jobs:
           ./git-chglog -o CHANGELOG.md
           rm git-chglog
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6.0.5
+        uses: peter-evans/create-pull-request@v6.1.0
         with:
           commit-message: update changelog
           title: Update Changelog

--- a/.github/workflows/nanoframework_dependabot.yml
+++ b/.github/workflows/nanoframework_dependabot.yml
@@ -27,7 +27,7 @@ jobs:
         uses: nuget/setup-nuget@v2.0.0
         with:
           nuget-version: '5.x'
-      - uses: nanoframework/nanodu@v1.0.23
+      - uses: nanoframework/nanodu@v1.0.24
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v6.1.0](https://github.com/peter-evans/create-pull-request/releases/tag/v6.1.0)** on 2024-06-18T16:54:59Z
* **[nanoframework/nanodu](https://github.com/nanoframework/nanodu)** published a new release **[v1.0.24](https://github.com/nanoframework/nanodu/releases/tag/v1.0.24)** on 2024-06-18T00:11:43Z
